### PR TITLE
fix: remove vi mode plugin

### DIFF
--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -48,7 +48,6 @@ delib.module {
             enable = true;
             plugins = [
               { name = "zsh-users/zsh-autosuggestions"; }
-              { name = "jeffreytse/zsh-vi-mode"; }
               { name = "Aloxaf/fzf-tab"; }
               {
                 name = "plugins/git";
@@ -58,6 +57,7 @@ delib.module {
                 name = "jackharrisonsherlock/common";
                 tags = [ "as:theme" ];
               }
+              { name = "unixorn/fzf-zsh-plugin"; }
             ];
           };
 


### PR DESCRIPTION
vi mode was overriding the ctrl-r binding for fzf command history search

i rely on history search and found myself not using the vi mode plugin /shrug